### PR TITLE
Fix --version output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -91,6 +91,7 @@ dependencies = [
  "anstyle",
  "bitflags",
  "clap_lex",
+ "once_cell",
  "strsim",
 ]
 
@@ -179,6 +180,12 @@ name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+
+[[package]]
+name = "once_cell"
+version = "1.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
 name = "regex"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,12 +1,13 @@
 [package]
 name = "rust-for-it"
+description = "Wait for one or more services to be available before executing a command."
 version = "1.0.0"
 edition = "2021"
 authors = ["Sebastian Pipping <sebastian@pipping.org>"]
 license = "MIT"
 
 [dependencies]
-clap = "4.3.1"
+clap = { version = "4.3.1", features = ["cargo"] }
 lazy_static = "1.4.0"
 regex = "1.8.3"
 subprocess = "0.2.9"

--- a/src/command_line_parser.rs
+++ b/src/command_line_parser.rs
@@ -3,7 +3,7 @@
 // Copyright (c) 2023 Sebastian Pipping <sebastian@pipping.org>
 // SPDX-License-Identifier: MIT
 
-use clap::{Arg, ArgAction, Command};
+use clap::{command, Arg, ArgAction, Command};
 use lazy_static::lazy_static;
 use regex::Regex;
 
@@ -23,9 +23,7 @@ fn parse_service_syntax(text: &str) -> Result<String, String> {
 }
 
 pub fn command() -> Command {
-    Command::new("rust-for-it")
-        .about("Wait for one or more services to be available before executing a command.")
-        .version("0.1.0")
+    command!()
         .arg(
             Arg::new("quiet")
                 .action(ArgAction::SetTrue)


### PR DESCRIPTION
.. and have it remain in sync automatically by sourcing metadata from Cargo.toml at build time