### PR TITLE
CI: Make CI send pull requests for "cargo update"

### DIFF
--- a/.github/workflows/cargo_lock_autoupdate.yml
+++ b/.github/workflows/cargo_lock_autoupdate.yml
@@ -1,0 +1,52 @@
+# This file is part of the rust-for-it project.
+#
+# Copyright (c) 2023 Sebastian Pipping <sebastian@pipping.org>
+# SPDX-License-Identifier: MIT
+
+name: Keep Cargo.lock up to date
+
+on:
+  schedule:
+    - cron: '0 16 * * 5'  # Every Friday 4pm
+  workflow_dispatch:
+
+# NOTE: This will drop all permissions from GITHUB_TOKEN except metadata read,
+#       and then (re)add the ones listed below:
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  cargo_lock_autoupdate:
+    name: Keep Cargo.lock up to date
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Check out
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9  # v3.5.3
+
+      - name: Check for outdated Rust dependencies
+        run: |-
+          cargo update
+          git diff
+
+      - name: Create pull request from changes (if any)
+        id: create-pull-request
+        uses: peter-evans/create-pull-request@5b4a9f6a9e2af26e5f02351490b90d01eb8ec1e5  # v5.0.0
+        with:
+          author: 'cargo-update <cargo-update@tools.invalid>'
+          base: main
+          body: |-
+            For your consideration.
+
+            :warning: Please **CLOSE AND RE-OPEN** this pull request so that [further workflow runs get triggered](https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#triggering-further-workflow-runs) for this pull request.
+          branch: cargo-update
+          commit-message: "Cargo.lock: Mass-upgrade"
+          delete-branch: true
+          draft: true
+          labels: enhancement
+          title: "Cargo.lock: Mass-upgrade"
+
+      - name: Log pull request URL
+        if: "${{ steps.create-pull-request.outputs.pull-request-url }}"
+        run: |
+          echo "Pull request URL is: ${{ steps.create-pull-request.outputs.pull-request-url }}"


### PR DESCRIPTION
It seems that GitHub Dependabot only updates direct dependencies from `Cargo.toml`, not _indirect_ ones only found in `Cargo.lock`. So this new CI fills that gap.

It needs this repository setting to be able to operate:

![permissions](https://github.com/google/yapf/assets/1577132/66694cb2-0736-4c2b-b937-31cacf470309)

Pull request #20 was already created by this automation.

CC @grandchild